### PR TITLE
RSDEV-444: Upgrade rspace-audit to 1.0.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # changes
 
+## 1.0.0 2026-04-29
+- Spring 6 / Hibernate 6 / Jakarta namespace migration
+- Switch to rspace-parent 3.0.0
+
 ## 0.14.2 2026-01-13
 
 - switch to parent-pom 2.1.1 (upgrades various dependencies)

--- a/pom.xml
+++ b/pom.xml
@@ -52,17 +52,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-audit</artifactId>
-  <version>0.14.3</version>
+  <version>1.0.0</version>
   <name>RSpace Audit trail</name>
 
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>
-    <version>2.1.3</version>
+    <version>3.0.0</version>
   </parent>
 
   <repositories>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-util</artifactId>
-      <version>1.1.0</version>
+      <version>2.0.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>
-    <version>3.0.0</version>
+    <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
   </parent>
 
   <repositories>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-util</artifactId>
-      <version>2.0.0</version>
+      <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/researchspace/service/audit/search/LogLineContentProviderImpl.java
+++ b/src/main/java/com/researchspace/service/audit/search/LogLineContentProviderImpl.java
@@ -16,7 +16,7 @@ public class LogLineContentProviderImpl implements LogLineContentProvider {
 
 	static final String cacheKeySpel = "getName()";
 
-	static final String cacheArg = "#logFile.";
+	static final String cacheArg = "#p1.";
 
 	static final String cacheUnless = "getName() matches '.*\\.txt$'";
 	


### PR DESCRIPTION
Upgrade rspace-audit to 1.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

Bumps parent pom and switches the SpEL cache key in `LogLineContentProviderImpl` to a positional `#p1` reference so the expression resolves without `-parameters` under Spring 6.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>